### PR TITLE
Double App Drawer Icons + Additional Squares

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,11 +12,6 @@
         <activity
             android:name=".SplashActivity"
             android:theme="@style/SplashTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/isaaclyman/humanbingo/PeopleSquares.kt
+++ b/app/src/main/java/com/isaaclyman/humanbingo/PeopleSquares.kt
@@ -100,8 +100,13 @@ class PeopleSquares {
                 "Accidental collision",
                 "Sunburn",
                 "Animal lover",
-                "Frosted tips"
+                "Frosted tips",
                 // 90
+                "Two Phones",
+                "Umbrella",
+                "Local School Pride",
+                "Athletic Jersey",
+                "Matching Outfits"
         )
     }
 }


### PR DESCRIPTION
### Double Icons
Removed `<intent-filter>` from the Splash screen in AndroidManifest.xml so that downloading from the Play Store will only create one Icon in the App Drawer. 
### Additional Square Options
Added 5 squares to the options list. 